### PR TITLE
Limit compaction

### DIFF
--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -613,7 +613,8 @@ unlogged_batch_across_partitions_warn_threshold: 10
 #
 # If your data directories are backed by SSD, you should increase this
 # to the number of cores.
-# concurrent_compactors: 4
+concurrent_compactors: 1
+in_memory_compaction_limit_in_mb: 2
 
 # Throttles compaction to the given total throughput across the entire
 # system. The faster you insert data, the faster you need to compact in


### PR DESCRIPTION
We create and drop tables a *lot* in the tests, and if compactions occur, this can lead to problems with the schema mutation lock's heartbeat. This is an attempt to rectify that.