### PR TITLE
Remove cassandra-topology.properties if we are using the GossipingPropertyFileSnitch

### DIFF
--- a/cassandra-env.sh
+++ b/cassandra-env.sh
@@ -261,7 +261,7 @@ JVM_OPTS="$JVM_OPTS -XX:GCLogFileSize=10M"
 # comment out this entry to enable IPv6 support).
 JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"
 
-# jmx: metrics and administration interface
+# JMX: metrics and administration interface
 #
 # add this if you're having trouble connecting:
 # JVM_OPTS="$JVM_OPTS -Djava.rmi.server.hostname=<public name>"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,12 @@ if [ "$1" = 'cassandra' ]; then
         fi
     done
 
+    # Should not have cassandra-topology.properties if we are using the GossipingPropertyFileSnitch
+    snitch=$(grep "endpoint_snitch:" "$CASSANDRA_CONFIG/cassandra.yaml" | cut -d$" " -f 2)
+    if [ "$snitch" = 'GossipingPropertyFileSnitch' ]; then
+        rm "$CASSANDRA_CONFIG/cassandra-topology.properties"
+    fi
+
     for rackdc in dc rack; do
         var="$(echo CASSANDRA_${rackdc} | tr '[:lower:]' '[:upper:]')"
         val="$(eval "echo \$${var}")"


### PR DESCRIPTION
I suspect this was causing the recent flakes we've seen, since the default datacenter in that file is DC1