### PR TITLE
Bump palantir cassandra image to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM cassandra:2.2.9
+FROM cassandra:3.11
 
 RUN apt-get update && apt-get install -y curl
-RUN curl -Lk https://bintray.com/palantir/releases/download_file?file_path=com%2Fpalantir%2Fcassandra%2Fpalantir-cassandra%2F2.2.13-1.5.0%2Fpalantir-cassandra-2.2.13-1.5.0.tgz | tar -zxv
-ENV PATH palantir-cassandra-2.2.13-1.5.0/bin:$PATH
+RUN curl -Lk https://bintray.com/palantir/releases/download_file?file_path=com%2Fpalantir%2Fcassandra%2Fpalantir-cassandra%2F3.11.4-pt-2.0.0-rc7%2Fpalantir-cassandra-3.11.4-pt-2.0.0-rc7.tgz | tar -zxv
+ENV PATH palantir-cassandra-3.11.4-pt-2.0.0-rc7/bin:$PATH
 
 ENV _JAVA_OPTIONS=-Dcassandra.skip_wait_for_gossip_to_settle=0
 ENV CASSANDRA_COMMAND cassandra
-ENV CASSANDRA_CONFIG palantir-cassandra-2.2.13-1.5.0/conf/
+ENV CASSANDRA_CONFIG palantir-cassandra-3.11.4-pt-2.0.0-rc7/conf/
 ENV CASSANDRA_YAML $CASSANDRA_CONFIG/cassandra.yaml
 ENV CASSANDRA_ENV $CASSANDRA_CONFIG/cassandra-env.sh
 


### PR DESCRIPTION
@jeremyk-91 @gmaretic @tpetracca 

I'd like to publish this image as "palantirtechnologies/docker-cassandra-atlasdb:3.11.4-pt-2.0.0-rc7".  What are the steps I need to take to do that?